### PR TITLE
Use %TypedArray% in the rough polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,15 +62,15 @@ function at(n) {
 	// ToInteger() abstract op
 	n = Math.trunc(n) || 0;
 	// Allow negative indexing from the end
-	if(n < 0) n += this.length;
+	if (n < 0) n += this.length;
 	// OOB access is guaranteed to return undefined
-	if(n < 0 || n >= this.length) return undefined;
+	if (n < 0 || n >= this.length) return undefined;
 	// Otherwise, this is just normal property access
 	return this[n];
 }
 
-// Other TypedArray constructors omitted for brevity.
-for (let C of [Array, String, Uint8Array]) {
+const TypedArray = Reflect.getPrototypeOf(Int8Array);
+for (const C of [Array, String, TypedArray]) {
     Object.defineProperty(C.prototype, "at",
                           { value: at,
                             writable: true,


### PR DESCRIPTION
The comment about not listing every TypedArray was just as long as the line of code that it took to actually apply the example polyfill to all of them.

It also shows where .at() actually is located.